### PR TITLE
feat(csrfDoubleSubmit): allow annotation csrfDoubleSubmit on controller class

### DIFF
--- a/Annotation/CsrfDoubleSubmit.php
+++ b/Annotation/CsrfDoubleSubmit.php
@@ -12,7 +12,7 @@ namespace Bazinga\Bundle\RestExtraBundle\Annotation;
 
 /**
  * @Annotation
- * @Target("METHOD")
+ * @Target({"CLASS","METHOD"})
  */
 final class CsrfDoubleSubmit
 {

--- a/EventListener/CsrfDoubleSubmitListener.php
+++ b/EventListener/CsrfDoubleSubmitListener.php
@@ -64,7 +64,7 @@ class CsrfDoubleSubmitListener
         $object = new \ReflectionObject($controller[0]);
         $method = $object->getMethod($controller[1]);
 
-        if (false === $this->isProtectedByCsrfDoubleSubmit($method)) {
+        if (false === $this->isProtectedByCsrfDoubleSubmit($object, $method)) {
             return;
         }
 
@@ -90,8 +90,17 @@ class CsrfDoubleSubmitListener
     /**
      * @return boolean
      */
-    private function isProtectedByCsrfDoubleSubmit(\ReflectionMethod $method)
+    private function isProtectedByCsrfDoubleSubmit(\ReflectionClass $class, \ReflectionMethod $method)
     {
+        $annotation = $this->annotationReader->getClassAnnotation(
+            $class,
+            'Bazinga\Bundle\RestExtraBundle\Annotation\CsrfDoubleSubmit'
+        );
+
+        if (null !== $annotation) {
+            return true;
+        }
+
         $annotation = $this->annotationReader->getMethodAnnotation(
             $method,
             'Bazinga\Bundle\RestExtraBundle\Annotation\CsrfDoubleSubmit'

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -63,6 +63,24 @@ public function createAction()
 }
 ```
 
+Or you could protect a controller with the **CSRF double submit** mechanism
+by using the `@CsrfDoubleSubmit` annotation, all methods except `GET, HEAD, OPTIONS, TRACE`
+will be protected:
+
+``` php
+use Bazinga\Bundle\RestExtraBundle\Annotation\CsrfDoubleSubmit;
+
+// ...
+
+/**
+ * @CsrfDoubleSubmit
+ */
+class ApiController
+{
+    // ...
+}
+```
+
 #### LinkRequestListener
 
 The `LinkRequestListener` listener is able to convert **links**, as described in

--- a/Tests/EventListener/CsrfDoubleSubmitListenerTest.php
+++ b/Tests/EventListener/CsrfDoubleSubmitListenerTest.php
@@ -110,6 +110,56 @@ class CsrfDoubleSubmitListenerTest extends WebTestCase
         );
     }
 
+    public function testCsrfDoubleSubmitClass()
+    {
+        $csrfValue = 'Sup3r$ecr3t';
+
+        $client = $this->createClient();
+        $client->getCookieJar()->set(new Cookie('csrf_cookie', $csrfValue));
+
+        $crawler = $client->request('POST', '/tests-csrf-class', array(
+            '_csrf_token' => $csrfValue,
+        ));
+
+        $request  = $client->getRequest();
+        $response = $client->getResponse();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(
+            'Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller\TestCsrfController::createAction',
+            $response->getContent()
+        );
+        $this->assertCount(0, $response->headers->getCookies());
+    }
+
+    /**
+     * @expectedException        Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @expectedExceptionMessage Cookie not found or invalid.
+     */
+    public function testCsrfDoubleSubmitClassFailsIfNoCookieFound()
+    {
+        $client  = $this->createClient();
+        $crawler = $client->request('POST', '/tests-csrf-class', array(
+            '_csrf_token' => '',
+        ));
+    }
+
+    public function testCsrfDoubleSubmitClassGETMethod()
+    {
+        $client = $this->createClient();
+
+        $crawler = $client->request('GET', '/tests-csrf-class');
+
+        $request  = $client->getRequest();
+        $response = $client->getResponse();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(
+            'Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller\TestCsrfController::getAction',
+            $response->getContent()
+        );
+    }
+
     public static function dataProviderWithInvalidData()
     {
         return array(

--- a/Tests/Fixtures/Controller/TestCsrfController.php
+++ b/Tests/Fixtures/Controller/TestCsrfController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Bazinga\Bundle\RestExtraBundle\Annotation\CsrfDoubleSubmit;
+
+/**
+ * @CsrfDoubleSubmit
+ */
+class TestCsrfController
+{
+    public function createAction()
+    {
+        return new Response(__METHOD__);
+    }
+
+    public function getAction()
+    {
+        return new Response(__METHOD__);
+    }
+}

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -35,3 +35,15 @@ test_create_without_csrf_double_submit:
     defaults: { _controller: BazingaRestExtraTestBundle:Test:createWithoutCsrfDoubleSubmit, _format: ~ }
     requirements:
         _method: POST
+
+test_create_csrf_class:
+    pattern:  /tests-csrf-class
+    defaults: { _controller: BazingaRestExtraTestBundle:TestCsrf:create, _format: ~ }
+    requirements:
+        _method: POST
+
+test_get_csrf_class:
+    pattern:  /tests-csrf-class
+    defaults: { _controller: BazingaRestExtraTestBundle:TestCsrf:get, _format: ~ }
+    requirements:
+        _method: GET


### PR DESCRIPTION
hi,

this allow the annotation `csrfDoubleSubmit` to be use on a controller class.  
