### PR TITLE
Use rel to group links

### DIFF
--- a/Model/LinkHeader.php
+++ b/Model/LinkHeader.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bazinga\Bundle\RestExtraBundle\Model;
+
+class LinkHeader
+{
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var string
+     */
+    private $rel;
+
+    /**
+     * @param string $url
+     * @param string $rel
+     */
+    public function __construct($url, $rel)
+    {
+        $this->url = trim($url);
+        $this->rel = trim($rel);
+    }
+
+    /**
+     * @return string
+     */
+    public function getRel()
+    {
+        return $this->rel;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasRel()
+    {
+        return !empty($this->rel);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+}

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -93,7 +93,7 @@ into PHP **objects**. This listener makes two **strong** assumptions:
   and MUST NOT use [Param
   Converters](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html);
 
-* This method MUST return an `array`, such as `array('user' => $user)`.
+* This method MUST return an `array`, such as `array('user' => $user)` **OR** return the object itself, such as `$user`.
 
 If it is ok for you, then turn the listener on in the configuration:
 
@@ -110,8 +110,16 @@ if (!$request->attributes->has('links')) {
     throw new HttpException(400, 'No links found');
 }
 
+// When *not* using rel in the links (e.g. Link: <http://host/resource>)
 foreach ($request->attributes->get('links') as $linkObject) {
     // ...
+}
+
+// When using rel in the links (e.g. Link: <http://host/resource>; rel="context1", <http://host/resource>; rel="context2")
+foreach ($request->attributes->get('links') as $context => $links) {
+    foreach( $links as $linkObject) {
+      // ...
+    }
 }
 ```
 

--- a/Tests/EventListener/LinkRequestListenerTest.php
+++ b/Tests/EventListener/LinkRequestListenerTest.php
@@ -12,7 +12,7 @@ class LinkRequestListenerTest extends WebTestCase
     public function testLink($uri, $linkUri)
     {
         $client  = $this->createClient();
-        $crawler = $client->request('LINK', $uri,
+        $client->request('LINK', $uri,
             array(),
             array(),
             array('HTTP_LINK' => sprintf($linkUri, 2), 'HTTP_ORIGIN' => 'http://localhost')
@@ -24,8 +24,11 @@ class LinkRequestListenerTest extends WebTestCase
         $links = $request->attributes->get('links');
         $this->assertCount(1, $links);
 
-        $this->assertInstanceOf('Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Model\Test', $links[0]);
-        $this->assertEquals(2, $links[0]->getId());
+        $link = array_shift($links);
+        $object = is_array($link) ? $link[0] : $link;
+
+        $this->assertInstanceOf('Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Model\Test', $object);
+        $this->assertEquals(2, $object->getId());
     }
 
     public function linkDataProvider()
@@ -33,7 +36,8 @@ class LinkRequestListenerTest extends WebTestCase
         return array(
           array('/tests/1', '</tests/%d>'),
           array('/tests/1', '<http://localhost/tests/%d>'),
-          array('/tests/1', '</tests/noconventions/%d>')
+          array('/tests/1', '</tests/noconventions/%d>'),
+          array('/tests/1', '</tests/noconventions/%d>; rel="test"')
         );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "symfony/finder": "~2.1",
-        "symfony/browser-kit": "~2.1"
+        "symfony/browser-kit": "~2.1",
+        "symfony/yaml": "~2.1"
     },
     "autoload": {
         "psr-0": { "Bazinga\\Bundle\\RestExtraBundle": "" }


### PR DESCRIPTION
This is a POC to regroup links based on the given rel. (see #9)

Currently this introduces a BC-Break. We could activate/deactivate this behaviour through config.
