### PR TITLE
[Feature] Add support for @ParamConverter in LinkRequestListener

### DIFF
--- a/EventListener/LinkRequestListener.php
+++ b/EventListener/LinkRequestListener.php
@@ -11,9 +11,11 @@
 namespace Bazinga\Bundle\RestExtraBundle\EventListener;
 
 use Bazinga\Bundle\RestExtraBundle\Model\LinkHeader;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -97,6 +99,11 @@ class LinkRequestListener
             if (false === $controller = $this->resolver->getController($stubRequest)) {
                 continue;
             }
+
+            // Make sure @ParamConverter and some other annotations are called
+            $subEvent = new FilterControllerEvent($event->getKernel(), $controller, $stubRequest, HttpKernelInterface::MASTER_REQUEST);
+            $event->getDispatcher()->dispatch(KernelEvents::CONTROLLER, $subEvent);
+            $controller = $subEvent->getController();
 
             $arguments = $this->resolver->getArguments($stubRequest, $controller);
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -89,9 +89,7 @@ about REST APIs with Symfony2](http://williamdurand.fr/2012/08/02/rest-apis-with
 into PHP **objects**. This listener makes two **strong** assumptions:
 
 * Your `getAction()` action (naming does not matter here), also known as the
-  action used to retrieve a specific resource must take the `identifier` as is,
-  and MUST NOT use [Param
-  Converters](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html);
+  action used to retrieve a specific resource must take the `identifier` as is;
 
 * This method MUST return an `array`, such as `array('user' => $user)` **OR** return the object itself, such as `$user`.
 

--- a/Tests/EventListener/LinkRequestListenerTest.php
+++ b/Tests/EventListener/LinkRequestListenerTest.php
@@ -31,6 +31,28 @@ class LinkRequestListenerTest extends WebTestCase
         $this->assertEquals(2, $object->getId());
     }
 
+    public function testLinkParamConverter()
+    {
+        $client  = $this->createClient();
+        $client->request('LINK', '/tests/1',
+            array(),
+            array(),
+            array('HTTP_LINK' => '</tests/paramconverter/2013-12-10>', 'HTTP_ORIGIN' => 'http://localhost')
+        );
+        $request = $client->getRequest();
+
+        $this->assertTrue($request->attributes->has('links'));
+
+        $links = $request->attributes->get('links');
+        $this->assertCount(1, $links);
+
+        $link = array_shift($links);
+        $object = is_array($link) ? $link[0] : $link;
+
+        $this->assertInstanceOf('DateTime', $object);
+        $this->assertEquals('2013-12-10', $object->format('Y-m-d'));
+    }
+
     public function linkDataProvider()
     {
         return array(

--- a/Tests/Fixtures/Controller/TestController.php
+++ b/Tests/Fixtures/Controller/TestController.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Bazinga\Bundle\RestExtraBundle\Annotation\CsrfDoubleSubmit;
 use Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Model\Test;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 
 class TestController
 {
@@ -17,6 +18,14 @@ class TestController
     public function getNoConventionAction($id)
     {
         return new Test($id);
+    }
+
+    /**
+     * @ParamConverter("date", options={"format": "Y-m-d"})
+     */
+    public function getParamConverterAction(\DateTime $date)
+    {
+        return array('date' => $date);
     }
 
     public function linkAction($id)

--- a/Tests/Fixtures/app/AppKernel.php
+++ b/Tests/Fixtures/app/AppKernel.php
@@ -17,6 +17,7 @@ class AppKernel extends Kernel
     {
         return array(
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new \Bazinga\Bundle\RestExtraBundle\BazingaRestExtraBundle(),
             new \Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\BazingaRestExtraTestBundle(),
         );

--- a/Tests/Fixtures/app/config/routing.yml
+++ b/Tests/Fixtures/app/config/routing.yml
@@ -10,6 +10,12 @@ test_get_no_convention:
     requirements:
         _method: GET
 
+test_get_param_converter:
+    pattern: /tests/paramconverter/{date}
+    defaults: { _controller: BazingaRestExtraTestBundle:Test:getParamConverter, _format: ~ }
+    requirements:
+        _method: GET
+
 test_link:
     pattern:  /tests/{id}
     defaults: { _controller: BazingaRestExtraTestBundle:Test:link, _format: ~ }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -23,3 +23,13 @@ AnnotationRegistry::registerLoader(function ($class) {
 
     return class_exists($class, false);
 });
+
+AnnotationRegistry::registerLoader(function ($class) {
+    if ($class == 'Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter') {
+        $path = __DIR__.'/../vendor/sensio/framework-extra-bundle/Sensio/Bundle/FrameworkExtraBundle/Configuration/ParamConverter.php';
+
+        require_once $path;
+    }
+
+    return class_exists($class, false);
+});

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require-dev": {
         "symfony/finder": "~2.1",
         "symfony/browser-kit": "~2.1",
-        "symfony/yaml": "~2.1"
+        "symfony/yaml": "~2.1",
+        "sensio/framework-extra-bundle": "~2.1"
     },
     "autoload": {
         "psr-0": { "Bazinga\\Bundle\\RestExtraBundle": "" }


### PR DESCRIPTION
The `@ParamConverter` annotation, and other request variable modifying annotations are often used in REST APIs.
Most, if not all, of those annotations hook on to the `kernel.controller` event to do their jobs.
By emitting such event in the `LinkRequestListener`, the arguments to the controller are modified, and the developer does not have to care if their actions are called by this listener, or from an external request.

Please let me know if you are interested in this feature addition, then I'll update the docs and add some tests.

Refs: willdurand/willdurand.github.com#21
