### PR TITLE
Change the subEvent from a MASTER_REQUEST to a SUB_REQUEST

### DIFF
--- a/EventListener/LinkRequestListener.php
+++ b/EventListener/LinkRequestListener.php
@@ -101,7 +101,7 @@ class LinkRequestListener
             }
 
             // Make sure @ParamConverter and some other annotations are called
-            $subEvent = new FilterControllerEvent($event->getKernel(), $controller, $stubRequest, HttpKernelInterface::MASTER_REQUEST);
+            $subEvent = new FilterControllerEvent($event->getKernel(), $controller, $stubRequest, HttpKernelInterface::SUB_REQUEST);
             $event->getDispatcher()->dispatch(KernelEvents::CONTROLLER, $subEvent);
             $controller = $subEvent->getController();
 


### PR DESCRIPTION
Hey,

Since PR #11 my tests are failing on my API. The reason is that my API needs a token on each request, and it was not necessary to add them in the `links`. However in #11 it makes a MASTER_REQUEST sub call which of course triggers my token listener.

I changed it to a SUB_REQUEST, and all tests are still passing.

Question ... Is it really necessary that the subEvent is called with a MASTER_REQUEST? 
