### PR TITLE
[1.2] Rework travis tests matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,77 @@
 language: php
+sudo: false
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+        - $HOME/symfony-bridge/.phpunit
 
 php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
     - hhvm
 
 env:
-    - SYMFONY_VERSION=2.8.*
-    - SYMFONY_VERSION=3.0.*
+    global:
+        - PHPUNIT_FLAGS="-v"
+        - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+        - SYMFONY_VERSION="^3.4"
+        - DEPENDENCIES="symfony/lts:^3"
 
 matrix:
+    fast_finish: true
     allow_failures:
-      - env: SYMFONY_VERSION=dev-master
       - php: hhvm
     include:
       - php: 5.5
-        env: SYMFONY_VERSION=2.1.*
+        env: SYMFONY_VERSION=2.1.* DEPENDENCIES="symfony/lts:^2"
       - php: 5.5
-        env: SYMFONY_VERSION=2.2.*
+        env: SYMFONY_VERSION=2.2.* DEPENDENCIES="symfony/lts:^2"
       - php: 5.5
-        env: SYMFONY_VERSION=2.3.*
+        env: SYMFONY_VERSION=2.3.* DEPENDENCIES="symfony/lts:^2"
       - php: 5.5
-        env: SYMFONY_VERSION=2.4.*
+        env: SYMFONY_VERSION=2.4.* DEPENDENCIES="symfony/lts:^2"
       - php: 5.5
-        env: SYMFONY_VERSION=2.5.*
+        env: SYMFONY_VERSION=2.5.* DEPENDENCIES="symfony/lts:^2"
       - php: 5.5
-        env: SYMFONY_VERSION=2.6.*
+        env: SYMFONY_VERSION=2.6.* DEPENDENCIES="symfony/lts:^2"
       - php: 5.5
-        env: SYMFONY_VERSION=2.7.*
-      - php: 5.3
-        env: SYMFONY_VERSION=2.8.*
+        env: SYMFONY_VERSION=2.7.* DEPENDENCIES="symfony/lts:^2"
+      - php: 7.0
+        env: SYMFONY_VERSION=2.8.* DEPENDENCIES="symfony/lts:^2"
+      - php: 5.6
+        env: SYMFONY_VERSION=2.8.* DEPENDENCIES="symfony/lts:^2"
+      - php: 5.5
+        env: SYMFONY_VERSION=2.8.* DEPENDENCIES="symfony/lts:^2"
       - php: 5.4
-        env: SYMFONY_VERSION=2.8.*
-      - php: 5.5
-        env: SYMFONY_VERSION=dev-master
+        env: SYMFONY_VERSION=2.8.* DEPENDENCIES="symfony/lts:^2"
 
-before_script:
-    - composer self-update
-    - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
-    - composer update
+      # Minimum supported dependencies with the latest and oldest PHP version
+      - php: 7.2
+        env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+      - php: 5.5
+        env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+
+
+      - php: 7.2
+        env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
+
+before_install:
+    - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
+    - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
+
+install:
+    # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
+    - composer require symfony/framework-bundle:${SYMFONY_VERSION} symfony/http-foundation:${SYMFONY_VERSION} --no-update
+    - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
+    - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
+    # prevent issue with --prefer-lower
+    - composer require --dev "symfony/phpunit-bridge":"^4.1@dev"
+    - ./vendor/bin/simple-phpunit install
 
 script:
-    - phpunit --coverage-text
+    - composer validate --strict --no-check-lock
+    # simple-phpunit is the PHPUnit wrapper provided by the PHPUnit Bridge component and
+    # it helps with testing legacy code and deprecations (composer require symfony/phpunit-bridge)
+    - ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS

--- a/Tests/EventListener/LinkRequestListenerTest.php
+++ b/Tests/EventListener/LinkRequestListenerTest.php
@@ -20,7 +20,7 @@ class LinkRequestListenerTest extends WebTestCase
         if (true === $forceScriptName) {
             $headers['SCRIPT_FILENAME']     = '/app.php';
             $headers['SCRIPT_NAME']         = '/app.php';
-            $headers['HTTP_X_ORIGINAL_URL'] = '/app.php' . $uri;
+            $uri = '/app.php' . $uri;
         }
 
         $client->request('LINK', $uri,

--- a/Tests/Fixtures/app/config/symfony-3/default.yml
+++ b/Tests/Fixtures/app/config/symfony-3/default.yml
@@ -1,10 +1,10 @@
 framework:
     secret:        test
     csrf_protection:
-        enabled: true
+        enabled: false
     router:        { resource: "%kernel.root_dir%/config/symfony-3/routing.yml" }
     test: ~
-    profiler:      { only_exceptions: false }
+    profiler:      false
     session: ~
 
 bazinga_rest_extra:

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,15 @@
     }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.1|~3.0"
+        "symfony/framework-bundle": "^3.4"
     },
     "require-dev": {
         "symfony/finder": "~2.1|~3.0",
         "symfony/browser-kit": "~2.1|~3.0",
         "symfony/yaml": "~2.1|~3.0",
         "symfony/form": "~2.1|~3.0",
-        "sensio/framework-extra-bundle": "~2.1|~3.0"
+        "sensio/framework-extra-bundle": "~2.1|~3.0",
+        "symfony/phpunit-bridge": "^4.1@dev"
     },
     "autoload": {
         "psr-4": { "Bazinga\\Bundle\\RestExtraBundle\\": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,12 +4,18 @@
     colors="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
+    convertWarningsToExceptions="false"
     processIsolation="false"
     stopOnFailure="false"
     syntaxCheck="false"
     bootstrap="./Tests/bootstrap.php"
     >
+
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+        <ini name="error_reporting" value="-1" />
+    </php>
 
     <testsuites>
         <testsuite name="BazingaRestExtraBundle Test Suite">
@@ -27,4 +33,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Use symfony/phpunit-bridge easier to run tests
Add tests for php 7.1, 7.2 for symfony LTS 3.4

Fix tests broken by a Symfony CVE fix
https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers