### PR TITLE
Handle controllers with magic method __invoke

### DIFF
--- a/EventListener/CsrfDoubleSubmitListener.php
+++ b/EventListener/CsrfDoubleSubmitListener.php
@@ -56,13 +56,15 @@ class CsrfDoubleSubmitListener
             return;
         }
 
-        // does not apply on closures
-        if (!is_array($controller)) {
+        if (is_array($controller)) {
+            $object = new \ReflectionObject($controller[0]);
+            $method = $object->getMethod($controller[1]);
+        } elseif (is_object($controller) && method_exists($controller, '__invoke')) {
+            $object = new \ReflectionObject($controller);
+            $method = $object->getMethod('__invoke');
+        } else {
             return;
         }
-
-        $object = new \ReflectionObject($controller[0]);
-        $method = $object->getMethod($controller[1]);
 
         if (false === $this->isProtectedByCsrfDoubleSubmit($object, $method)) {
             return;

--- a/Tests/Fixtures/Controller/TestInvokeController.php
+++ b/Tests/Fixtures/Controller/TestInvokeController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class TestInvokeController
+{
+    public function __invoke()
+    {
+        return new Response(__METHOD__);
+    }
+}

--- a/Tests/Fixtures/Controller/TestInvokeCsrfController.php
+++ b/Tests/Fixtures/Controller/TestInvokeCsrfController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller;
+
+use Bazinga\Bundle\RestExtraBundle\Annotation\CsrfDoubleSubmit;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @CsrfDoubleSubmit
+ */
+class TestInvokeCsrfController
+{
+    public function __invoke()
+    {
+        return new Response(__METHOD__);
+    }
+}

--- a/Tests/Fixtures/app/config/symfony-3/routing.yml
+++ b/Tests/Fixtures/app/config/symfony-3/routing.yml
@@ -51,3 +51,13 @@ test_get_csrf_class:
     path:  /tests-csrf-class
     defaults: { _controller: BazingaRestExtraTestBundle:TestCsrf:get, _format: ~ }
     methods: GET
+
+test_invoke_csrf_class:
+    path:  /tests/invoke
+    defaults: { _controller: Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller\TestInvokeCsrfController, _format: ~ }
+    methods: POST
+
+test_invoke:
+    path:  /tests/invoke-without-csrf
+    defaults: { _controller: Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller\TestInvokeController, _format: ~ }
+    methods: POST

--- a/Tests/Fixtures/app/config/symfony-4/routing.yml
+++ b/Tests/Fixtures/app/config/symfony-4/routing.yml
@@ -51,3 +51,13 @@ test_get_csrf_class:
     path:  /tests-csrf-class
     defaults: { _controller: Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller\TestCsrfController::getAction, _format: ~ }
     methods: GET
+
+test_invoke_csrf_class:
+    path:  /tests/invoke
+    defaults: { _controller: Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller\TestInvokeCsrfController, _format: ~ }
+    methods: POST
+
+test_invoke:
+    path:  /tests/invoke-without-csrf
+    defaults: { _controller: Bazinga\Bundle\RestExtraBundle\Tests\Fixtures\Controller\TestInvokeController, _format: ~ }
+    methods: POST


### PR DESCRIPTION
I made this PR because in the listener CsrfDoubleSubmitListener::onKernelController, $event->getController is expected to return an array
0 -> controller object
1 -> methodName

When we use magic method __invoke, getController returns an object (the controller)
